### PR TITLE
Add additional section/slug field into NoteConfig window

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -60,11 +60,7 @@ Hooks.on("renderNoteConfig", async (app,html,data) => {
 		const newpageid    = app.form.elements.pageId?.value;
 		const journal = game.journal.get(newjournalid);
 		const newpage = journal?.pages.get(newpageid);
-		console.log(`selected page changed to ${newpageid}`);
-
-		console.log("new options =", getOptions(newpage, data.document.flags.anchor?.slug));
 		app.form.elements["flags.anchor.slug"].innerHTML = getOptions(newpage, data.document.flags.anchor?.slug);
-		console.log("new innerHtml", app.form.elements["flags.anchor.slug"].innerHTML);
 	}
 	html.find("select[name='entryId']").change(_updateSectionList);
 	pageid.change(_updateSectionList);

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -37,3 +37,42 @@ Hooks.on("dropCanvasData", (canvas, data) => {
 Hooks.on("activateNote", (note, options) => {
 	options.anchor = note.document.flags.anchor?.slug;
 });
+
+
+function getOptions(page,current) {
+	let options = "<option></option>";
+	if (page?.type === "text") {
+		for (const section of Object.values(page.toc)) {
+			options += `<option value="${section.slug}"${section.slug === current ? " selected" : ""}>${section.text}</option>`;
+		}
+	}
+	return options;
+}
+
+Hooks.on("renderNoteConfig", async (app,html,data) => {
+	let select = $(`<div class='form-group'><label>Page Section:</label><div class='form-fields'><select name="flags.anchor.slug">${getOptions(data.document.page, data.document.flags.anchor?.slug)}</select></div></div>`)
+	const pageid = html.find("select[name='pageId']");
+	pageid.parent().parent().after(select);
+
+	// on change of page or journal entry
+	function _updateSectionList() {
+		const newjournalid = app.form.elements.entryId?.value;
+		const newpageid    = app.form.elements.pageId?.value;
+		const journal = game.journal.get(newjournalid);
+		const newpage = journal?.pages.get(newpageid);
+		console.log(`selected page changed to ${newpageid}`);
+
+		console.log("new options =", getOptions(newpage, data.document.flags.anchor?.slug));
+		app.form.elements["flags.anchor.slug"].innerHTML = getOptions(newpage, data.document.flags.anchor?.slug);
+		console.log("new innerHtml", app.form.elements["flags.anchor.slug"].innerHTML);
+	}
+	html.find("select[name='entryId']").change(_updateSectionList);
+	pageid.change(_updateSectionList);
+
+    // Force a recalculation of the height (for the additional field)
+	if (!app._minimized) {
+		let pos = app.position;
+		pos.height = 'auto'
+		app.setPosition(pos);
+	}
+})


### PR DESCRIPTION
This small update adds an additional field into the NoteConfig window, so that a user can see the current slug and optionally update the slug to a different section within a page.

The list of valid slug names is regenerated whenever the journal entry or journal page is changed within the Note Config document.